### PR TITLE
setup.cfg: Fix deprecated usage of dashed key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bdist_wininst]
 bitmap=gamera/pixmaps/gamera_wizard.bmp
 title=Gamera 4
-install-script=gamera_post_install.py
+install_script=gamera_post_install.py
 
 [bdist_rpm]
 packager=Michael Droettboom <mdboom@jhu.edu>


### PR DESCRIPTION
Building the package currently warns about a deprecated key variant:

```
/opt/hostedtoolcache/Python/3.11.0-rc.2/x64/lib/python3.11/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'install-script' will not be supported in future versions. Please use the underscore name 'install_script' instead
  warnings.warn(
```

This PR adds the recommended fix.