### PR TITLE
Fix basic compiler warnings

### DIFF
--- a/include/plugins/binarization.hpp
+++ b/include/plugins/binarization.hpp
@@ -1024,8 +1024,9 @@ Image* brink_threshold(const T& image)
   for (i = 1; i < 256; ++i)         // get cumulative sum
     for (j = 0; j < 256; ++j)
       tmpMat1[i][j] = tmpMat1[i-1][j] + tmp4[i][j];
-    for (i = 0; i < 256; ++i)       // set to diagonal
-      tmpVec1[i] = tmpMat1[i][i];   // tmpVec1 is now the diagonal of the cumulative sum of tmp4
+
+  for (i = 0; i < 256; ++i)       // set to diagonal
+    tmpVec1[i] = tmpMat1[i][i];   // tmpVec1 is now the diagonal of the cumulative sum of tmp4
  
 
   // same operation but for background moment, NOTE: tmp1 through tmp4 get overwritten

--- a/include/vigra/README
+++ b/include/vigra/README
@@ -43,4 +43,14 @@ files are modified:
      fix for gcc 4.7. This change is already included in the
      development branch of VIGRA
 
+ - functortraits.hxx
+     remove deprecated std::binder1st and std::binder2nd. This
+     change has been backported from the development branch of
+     VIGRA
+
+ - static_assert.hxx
+     remove unnecessary parentheses (warning in gcc 9). This
+     change has been backported from the development branch of
+     VIGRA
+
 Christoph Dalitz

--- a/include/vigra/functortraits.hxx
+++ b/include/vigra/functortraits.hxx
@@ -163,8 +163,6 @@ VIGRA_DEFINE_STL_FUNCTOR(std::binary_negate, VigraFalseType, VigraTrueType)
 VIGRA_DEFINE_STL_FUNCTOR(std::negate, VigraTrueType, VigraFalseType)
 VIGRA_DEFINE_STL_FUNCTOR(std::logical_not, VigraTrueType, VigraFalseType)
 VIGRA_DEFINE_STL_FUNCTOR(std::unary_negate, VigraTrueType, VigraFalseType)
-VIGRA_DEFINE_STL_FUNCTOR(std::binder1st, VigraTrueType, VigraFalseType)
-VIGRA_DEFINE_STL_FUNCTOR(std::binder2nd, VigraTrueType, VigraFalseType)
 #undef VIGRA_DEFINE_STL_FUNCTOR
 
 template <class R>

--- a/include/vigra/static_assert.hxx
+++ b/include/vigra/static_assert.hxx
@@ -86,9 +86,8 @@ struct success {};
 inline int check( success ) { return 0; }
 
 template< typename Predicate >
-failure ************ (Predicate::************ 
-      assertImpl( void (*)(Predicate), typename Predicate::not_type )
-    );
+failure ************ Predicate::************ 
+      assertImpl( void (*)(Predicate), typename Predicate::not_type );
 
 template< typename Predicate >
 success

--- a/src/eodev/utils/eoState.cpp
+++ b/src/eodev/utils/eoState.cpp
@@ -131,8 +131,8 @@ void eoState::load(std::istream& is)
                   if (is_section(str, name))
                     break;
 
-                    removeComment(str, getCommentString());
-                    fullstring += str + "\n";
+                  removeComment(str, getCommentString());
+                  fullstring += str + "\n";
                 }
                 istringstream the_stream(fullstring);
                 object->readFrom(the_stream);


### PR DESCRIPTION
This fixes some basic compiler warnings which just pollute the build log. Fixes #42.

### binarization.hpp

```
include/plugins/binarization.hpp: In function ‘Gamera::Image* brink_threshold(const T&)’:
include/plugins/binarization.hpp:1024:3: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
 1024 |   for (i = 1; i < 256; ++i)         // get cumulative sum
      |   ^~~
include/plugins/binarization.hpp:1027:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
 1027 |     for (i = 0; i < 256; ++i)       // set to diagonal
      |     ^~~
```

### eoState.cpp

```
src/eodev/utils/eoState.cpp: In member function ‘void eoState::load(std::istream&)’:
src/eodev/utils/eoState.cpp:131:19: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  131 |                   if (is_section(str, name))
      |                   ^~
src/eodev/utils/eoState.cpp:134:21: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  134 |                     removeComment(str, getCommentString());
      |                     ^~~~~~~~~~~~~

```

### functortraits.hxx

Backport of https://github.com/ukoethe/vigra/commit/7a20c9b593d8137b8c1ac142882938c020e09a63.

### static_assert.hxx

Backport of https://github.com/ukoethe/vigra/commit/aaaf44d240aebd0eb3539b6e105a19a984000d81.