### PR TITLE
Use Py_SET_TYPE if available (required for Python 3.11)

### DIFF
--- a/src/gameracore/dimobject.cpp
+++ b/src/gameracore/dimobject.cpp
@@ -124,7 +124,11 @@ static PyGetSetDef dim_getset[] = {
 
 
 void init_DimType(PyObject* module_dict) {
-  Py_TYPE(&DimType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&DimType, &PyType_Type);
+  #else
+    Py_TYPE(&DimType) = &PyType_Type;
+  #endif
   DimType.tp_name =  "gameracore.Dim";
   DimType.tp_basicsize = sizeof(DimObject);
   DimType.tp_dealloc = dim_dealloc;

--- a/src/gameracore/floatpointobject.cpp
+++ b/src/gameracore/floatpointobject.cpp
@@ -208,7 +208,11 @@ void init_FloatPointType(PyObject* module_dict) {
   floatpoint_number_methods.nb_positive = floatpoint_positive;
   floatpoint_number_methods.nb_absolute = floatpoint_absolute;
 
-  Py_TYPE(&FloatPointType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&FloatPointType, &PyType_Type);
+  #else
+    Py_TYPE(&FloatPointType) = &PyType_Type;
+  #endif
   FloatPointType.tp_name =  "gameracore.FloatPoint";
   FloatPointType.tp_basicsize = sizeof(FloatPointObject);
   FloatPointType.tp_dealloc = floatpoint_dealloc;

--- a/src/gameracore/imagedataobject.cpp
+++ b/src/gameracore/imagedataobject.cpp
@@ -163,7 +163,11 @@ static PyMethodDef imagedata_methods[] = {
 };
 
 void init_ImageDataType(PyObject* module_dict) {
-  Py_TYPE(&ImageDataType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&ImageDataType, &PyType_Type);
+  #else
+    Py_TYPE(&ImageDataType) = &PyType_Type;
+  #endif
   ImageDataType.tp_name =  "gameracore.ImageData";
   ImageDataType.tp_basicsize = sizeof(ImageDataObject);
   ImageDataType.tp_dealloc = imagedata_dealloc;

--- a/src/gameracore/imageinfoobject.cpp
+++ b/src/gameracore/imageinfoobject.cpp
@@ -102,7 +102,11 @@ static PyGetSetDef imageinfo_getset[] = {
 };
 
 void init_ImageInfoType(PyObject* module_dict) {
-  Py_TYPE(&ImageInfoType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&ImageInfoType, &PyType_Type);
+  #else
+    Py_TYPE(&ImageInfoType) = &PyType_Type;
+  #endif
   ImageInfoType.tp_name =  "gameracore.ImageInfo";
   ImageInfoType.tp_basicsize = sizeof(ImageInfoObject);
   ImageInfoType.tp_dealloc = imageinfo_dealloc;

--- a/src/gameracore/imageobject.cpp
+++ b/src/gameracore/imageobject.cpp
@@ -1950,7 +1950,11 @@ static PyMethodDef mlcc_methods[] = {
 };
 
 void init_ImageType(PyObject *module_dict) {
-	Py_TYPE(&ImageType) = &PyType_Type;
+	#ifdef Py_SET_TYPE
+		Py_SET_TYPE(&ImageType, &PyType_Type);
+	#else
+		Py_TYPE(&ImageType) = &PyType_Type;
+	#endif
 	ImageType.tp_name =  "gameracore.Image";
 	ImageType.tp_basicsize = sizeof(ImageObject);
 	ImageType.tp_dealloc = image_dealloc;
@@ -1994,7 +1998,11 @@ void init_ImageType(PyObject *module_dict) {
 	PyType_Ready(&ImageType);
 	PyDict_SetItemString(module_dict, "Image", (PyObject *) &ImageType);
 	
-	Py_TYPE(&SubImageType) = &PyType_Type;
+	#ifdef Py_SET_TYPE
+		Py_SET_TYPE(&SubImageType, &PyType_Type);
+	#else
+		Py_TYPE(&SubImageType) = &PyType_Type;
+	#endif
 	SubImageType.tp_name =  "gameracore.SubImage";
 	SubImageType.tp_basicsize = sizeof(SubImageObject);
 	SubImageType.tp_dealloc = image_dealloc;
@@ -2023,7 +2031,11 @@ void init_ImageType(PyObject *module_dict) {
 	PyType_Ready(&SubImageType);
 	PyDict_SetItemString(module_dict, "SubImage", (PyObject *) &SubImageType);
 	
-	Py_TYPE(&CCType) = &PyType_Type;
+	#ifdef Py_SET_TYPE
+		Py_SET_TYPE(&CCType, &PyType_Type);
+	#else
+		Py_TYPE(&CCType) = &PyType_Type;
+	#endif
 	CCType.tp_name =  "gameracore.Cc";
 	CCType.tp_basicsize = sizeof(CCObject);
 	CCType.tp_dealloc = image_dealloc;
@@ -2054,7 +2066,11 @@ void init_ImageType(PyObject *module_dict) {
 	PyType_Ready(&CCType);
 	PyDict_SetItemString(module_dict, "Cc", (PyObject *) &CCType);
 	
-	Py_TYPE(&MLCCType) = &PyType_Type;
+	#ifdef Py_SET_TYPE
+		Py_SET_TYPE(&MLCCType, &PyType_Type);
+	#else
+		Py_TYPE(&MLCCType) = &PyType_Type;
+	#endif
 	MLCCType.tp_name =  "gameracore.MlCc";
 	MLCCType.tp_basicsize = sizeof(MLCCObject);
 	MLCCType.tp_dealloc = image_dealloc;

--- a/src/gameracore/iteratorobject.cpp
+++ b/src/gameracore/iteratorobject.cpp
@@ -47,7 +47,11 @@ PyObject* iterator_next(PyObject* self) {
 }
 
 void init_IteratorType(PyObject* module_dict) {
-  Py_TYPE(&IteratorType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&IteratorType, &PyType_Type);
+  #else
+    Py_TYPE(&IteratorType) = &PyType_Type;
+  #endif
   IteratorType.tp_name =  "gamera.Iterator";
   IteratorType.tp_basicsize = sizeof(IteratorObject);
   IteratorType.tp_dealloc = iterator_dealloc;

--- a/src/gameracore/pointobject.cpp
+++ b/src/gameracore/pointobject.cpp
@@ -191,7 +191,11 @@ static PyMethodDef point_methods[] = {
 void init_PointType(PyObject* module_dict) {
   point_number_methods.nb_add = point_add;
 
-  Py_TYPE(&PointType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&PointType, &PyType_Type);
+  #else
+    Py_TYPE(&PointType) = &PyType_Type;
+  #endif
   PointType.tp_name =  "gameracore.Point";
   PointType.tp_basicsize = sizeof(PointObject);
   PointType.tp_dealloc = point_dealloc;

--- a/src/gameracore/rectobject.cpp
+++ b/src/gameracore/rectobject.cpp
@@ -617,7 +617,11 @@ static PyMethodDef rect_methods[] = {
 
 
 void init_RectType(PyObject* module_dict) {
-  Py_TYPE(&RectType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&RectType, &PyType_Type);
+  #else
+    Py_TYPE(&RectType) = &PyType_Type;
+  #endif
   RectType.tp_name =  "gameracore.Rect";
   RectType.tp_basicsize = sizeof(RectObject);
   RectType.tp_dealloc = rect_dealloc;

--- a/src/gameracore/regionmapobject.cpp
+++ b/src/gameracore/regionmapobject.cpp
@@ -109,7 +109,11 @@ void init_RegionMapType(PyObject* module_dict) {
   RegionMapSequenceMethods.sq_item = regionmap___getitem__;
   RegionMapSequenceMethods.sq_length = regionmap___len__;
 
-  Py_TYPE(&RegionMapType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&RegionMapType, &PyType_Type);
+  #else
+    Py_TYPE(&RegionMapType) = &PyType_Type;
+  #endif
   RegionMapType.tp_name =  "gameracore.RegionMap";
   RegionMapType.tp_basicsize = sizeof(RegionMapObject);
   RegionMapType.tp_dealloc = regionmap_dealloc;

--- a/src/gameracore/regionobject.cpp
+++ b/src/gameracore/regionobject.cpp
@@ -105,7 +105,11 @@ static PyMethodDef region_methods[] = {
 };
 
 void init_RegionType(PyObject* module_dict) {
-  Py_TYPE(&RegionType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&RegionType, &PyType_Type);
+  #else
+    Py_TYPE(&RegionType) = &PyType_Type;
+  #endif
   RegionType.tp_name =  "gameracore.Region";
   RegionType.tp_basicsize = sizeof(RegionObject);
   RegionType.tp_dealloc = region_dealloc;

--- a/src/gameracore/rgbpixelobject.cpp
+++ b/src/gameracore/rgbpixelobject.cpp
@@ -193,7 +193,11 @@ static PyGetSetDef rgbpixel_getset[] = {
 };
 
 void init_RGBPixelType(PyObject* module_dict) {
-  Py_TYPE(&RGBPixelType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&RGBPixelType, &PyType_Type);
+  #else
+    Py_TYPE(&RGBPixelType) = &PyType_Type;
+  #endif
   RGBPixelType.tp_name =  "gameracore.RGBPixel";
   RGBPixelType.tp_basicsize = sizeof(RGBPixelObject);
   RGBPixelType.tp_dealloc = rgbpixel_dealloc;

--- a/src/gameracore/sizeobject.cpp
+++ b/src/gameracore/sizeobject.cpp
@@ -124,7 +124,11 @@ static PyGetSetDef size_getset[] = {
 };
 
 void init_SizeType(PyObject* module_dict) {
-  Py_TYPE(&SizeType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&SizeType, &PyType_Type);
+  #else
+    Py_TYPE(&SizeType) = &PyType_Type;
+  #endif
   SizeType.tp_name =  "gameracore.Size";
   SizeType.tp_basicsize = sizeof(SizeObject);
   SizeType.tp_dealloc = size_dealloc;

--- a/src/geostructs/kdtreemodule.cpp
+++ b/src/geostructs/kdtreemodule.cpp
@@ -121,7 +121,11 @@ PyGetSetDef kdnode_getset[] = {
 };
 
 void init_KdNodeType(PyObject* d) {
-    Py_TYPE(&KdNodeType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&KdNodeType, &PyType_Type);
+    #else
+      Py_TYPE(&KdNodeType) = &PyType_Type;
+    #endif
     KdNodeType.tp_name =  "gamera.kdtree.KdNode";
     KdNodeType.tp_basicsize = sizeof(KdNodeObject);
     KdNodeType.tp_dealloc = kdnode_dealloc;
@@ -368,7 +372,11 @@ PyGetSetDef kdtree_getset[] = {
 };
 
 void init_KdTreeType(PyObject* d) {
-  Py_TYPE(&KdTreeType) = &PyType_Type;
+  #ifdef Py_SET_TYPE
+    Py_SET_TYPE(&KdTreeType, &PyType_Type);
+  #else
+    Py_TYPE(&KdTreeType) = &PyType_Type;
+  #endif
   KdTreeType.tp_name =  "gamera.kdtree.KdTree";
   KdTreeType.tp_basicsize = sizeof(KdTreeObject);
   KdTreeType.tp_dealloc = kdtree_dealloc;

--- a/src/graph/graphmodule/edgeobject.cpp
+++ b/src/graph/graphmodule/edgeobject.cpp
@@ -241,7 +241,11 @@ PyGetSetDef edge_getset[] = {
 
 // -----------------------------------------------------------------------------
 void init_EdgeType() {
-	Py_TYPE(&EdgeType) = &PyType_Type;
+	#ifdef Py_SET_TYPE
+		Py_SET_TYPE(&EdgeType, &PyType_Type);
+	#else
+		Py_TYPE(&EdgeType) = &PyType_Type;
+	#endif
 	EdgeType.tp_name =  "gamera.graph.Edge";
 	EdgeType.tp_basicsize = sizeof(EdgeObject);
 	EdgeType.tp_dealloc = edge_dealloc;

--- a/src/graph/graphmodule/graphobject.cpp
+++ b/src/graph/graphmodule/graphobject.cpp
@@ -961,7 +961,11 @@ PyGetSetDef graph_getset[] = {
 
 // -----------------------------------------------------------------------------
 bool init_GraphType(PyObject* d) {
-    Py_TYPE(&GraphType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GraphType, &PyType_Type);
+    #else
+      Py_TYPE(&GraphType) = &PyType_Type;
+    #endif
     GraphType.tp_name =  "gamera.graph.Graph";
     GraphType.tp_basicsize = sizeof(GraphObject);
     GraphType.tp_dealloc = graph_dealloc;

--- a/src/graph/graphmodule/nodeobject.cpp
+++ b/src/graph/graphmodule/nodeobject.cpp
@@ -201,7 +201,11 @@ PyGetSetDef node_getset[] = {
 
 // -----------------------------------------------------------------------------
 void init_NodeType() {
-    Py_TYPE(&NodeType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&NodeType, &PyType_Type);
+    #else
+      Py_TYPE(&NodeType) = &PyType_Type;
+    #endif
     NodeType.tp_name =  "gamera.graph.Node";
     NodeType.tp_basicsize = sizeof(NodeObject);
     NodeType.tp_dealloc = node_dealloc;

--- a/src/knncore/knncoremodule.cpp
+++ b/src/knncore/knncoremodule.cpp
@@ -1515,7 +1515,11 @@ PyMODINIT_FUNC PyInit_knncore(void) {
     PyObject *m = PyModule_Create(&moduledef);
     PyObject* d = PyModule_GetDict(m);
 
-    Py_TYPE(&KnnType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&KnnType, &PyType_Type);
+    #else
+      Py_TYPE(&KnnType) = &PyType_Type;
+    #endif
     KnnType.tp_name =  "gamera.knncore.kNN";
     KnnType.tp_basicsize = sizeof(KnnObject);
     KnnType.tp_dealloc = knn_dealloc;

--- a/src/knnga/knngamodule.cpp
+++ b/src/knnga/knngamodule.cpp
@@ -222,7 +222,11 @@ PyGetSetDef GABaseSetting_getset[] = {
 };
 
 void init_GABaseSettingType(PyObject *d) {
-    Py_TYPE(&GABaseSettingType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GABaseSettingType, &PyType_Type);
+    #else
+      Py_TYPE(&GABaseSettingType) = &PyType_Type;
+    #endif
     GABaseSettingType.tp_name =  "gamera.knnga.GABaseSetting";
     GABaseSettingType.tp_basicsize = sizeof(GABaseSettingObject);
     GABaseSettingType.tp_dealloc = GABaseSetting_dealloc;
@@ -454,7 +458,11 @@ PyGetSetDef GASelection_getset[] = {
 };
 
 void init_GASelectionType(PyObject *d) {
-    Py_TYPE(&GASelectionType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GASelectionType, &PyType_Type);
+    #else
+      Py_TYPE(&GASelectionType) = &PyType_Type;
+    #endif
     GASelectionType.tp_name =  "gamera.knnga.GASelection";
     GASelectionType.tp_basicsize = sizeof(GASelectionObject);
     GASelectionType.tp_dealloc = GASelection_dealloc;
@@ -700,7 +708,11 @@ PyGetSetDef GACrossover_getset[] = {
 };
 
 void init_GACrossoverType(PyObject *d) {
-    Py_TYPE(&GACrossoverType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GACrossoverType, &PyType_Type);
+    #else
+      Py_TYPE(&GACrossoverType) = &PyType_Type;
+    #endif
     GACrossoverType.tp_name =  "gamera.knnga.GACrossover";
     GACrossoverType.tp_basicsize = sizeof(GACrossoverObject);
     GACrossoverType.tp_dealloc = GACrossover_dealloc;
@@ -914,7 +926,11 @@ PyGetSetDef GAMutation_getset[] = {
 };
 
 void init_GAMutationType(PyObject *d) {
-    Py_TYPE(&GAMutationType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GAMutationType, &PyType_Type);
+    #else
+      Py_TYPE(&GAMutationType) = &PyType_Type;
+    #endif
     GAMutationType.tp_name =  "gamera.knnga.GAMutation";
     GAMutationType.tp_basicsize = sizeof(GAMutationObject);
     GAMutationType.tp_dealloc = GAMutation_dealloc;
@@ -1062,7 +1078,11 @@ PyGetSetDef GAReplacement_getset[] = {
 };
 
 void init_GAReplacementType(PyObject *d) {
-    Py_TYPE(&GAReplacementType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GAReplacementType, &PyType_Type);
+    #else
+      Py_TYPE(&GAReplacementType) = &PyType_Type;
+    #endif
     GAReplacementType.tp_name =  "gamera.knnga.GAReplacement";
     GAReplacementType.tp_basicsize = sizeof(GAReplacementObject);
     GAReplacementType.tp_dealloc = GAReplacement_dealloc;
@@ -1249,7 +1269,11 @@ PyGetSetDef GAStopCriteria_getset[] = {
 };
 
 void init_GAStopCriteriaType(PyObject *d) {
-    Py_TYPE(&GAStopCriteriaType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GAStopCriteriaType, &PyType_Type);
+    #else
+      Py_TYPE(&GAStopCriteriaType) = &PyType_Type;
+    #endif
     GAStopCriteriaType.tp_name =  "gamera.knnga.GAStopCriteria";
     GAStopCriteriaType.tp_basicsize = sizeof(GAStopCriteriaObject);
     GAStopCriteriaType.tp_dealloc = GAStopCriteria_dealloc;
@@ -1410,7 +1434,11 @@ PyGetSetDef GAParallelization_getset[] = {
 };
 
 void init_GAParallelizationType(PyObject *d) {
-    Py_TYPE(&GAParallelizationType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GAParallelizationType, &PyType_Type);
+    #else
+      Py_TYPE(&GAParallelizationType) = &PyType_Type;
+    #endif
     GAParallelizationType.tp_name =  "gamera.knnga.GAParallelization";
     GAParallelizationType.tp_basicsize = sizeof(GAParallelizationObject);
     GAParallelizationType.tp_dealloc = GAParallelization_dealloc;
@@ -1800,7 +1828,11 @@ PyGetSetDef GAOptimization_getset[] = {
 };
 
 void init_GAOptimizationType(PyObject *d) {
-    Py_TYPE(&GAOptimizationType) = &PyType_Type;
+    #ifdef Py_SET_TYPE
+      Py_SET_TYPE(&GAOptimizationType, &PyType_Type);
+    #else
+      Py_TYPE(&GAOptimizationType) = &PyType_Type;
+    #endif
     GAOptimizationType.tp_name =  "gamera.knnga.GAOptimization";
     GAOptimizationType.tp_basicsize = sizeof(GAOptimizationObject);
     GAOptimizationType.tp_dealloc = GAOptimization_dealloc;


### PR DESCRIPTION
This PR prepares Python 3.11 compatibility (#54) by fixing the build errors which occur due to the removal of `Py_TYPE` (https://github.com/python/cpython/commit/f3fa63ec75fdbb4a08a10957a5c631bf0c4a5970). The new way is to use `Py_SET_TYPE` instead, which is available since Python 3.9 (the condition macro makes sure that older Python versions like Python 3.8 will not be dropped).