### PR TITLE
Replace py.test with pytest

### DIFF
--- a/doc/src/directory_hierarchy.txt
+++ b/doc/src/directory_hierarchy.txt
@@ -69,7 +69,7 @@ The Gamera source tree looks something like this:
 |                     |               | compiling convenience on MS-Windows and Mac    |
 |                     |               | OS-X.                                          |
 +---------------------+---------------+------------------------------------------------+
-| tests/              | Includes unit tests for running with the ``py.test`` framework.|
+| tests/              | Includes unit tests for running with the ``pytest`` framework. |
 |                     | These files are mainly useful only for the developers of       |
 |                     | Gamera.                                                        |
 +---------------------+---------------+------------------------------------------------+

--- a/doc/src/index.txt
+++ b/doc/src/index.txt
@@ -98,7 +98,7 @@ Reference
 
 - `Directory hierarchy`__: Where the files are.
 
-.. __: directory_heirarchy.html
+.. __: directory_hierarchy.html
 
 - `Image types`__: The different types of images available in Gamera
 

--- a/doc/src/unit_testing.txt
+++ b/doc/src/unit_testing.txt
@@ -6,39 +6,31 @@ Introduction
 ============
 
 Gamera does not contain its own unit testing framework, but instead
-uses the great `py.test`__ framework.  
+uses the great `pytest`__ framework.  
 
-.. note::
+.. __: https://pytest.org/
 
-  **py.test** is still considered beta-level software, and is somewhat
-  cumbersome to install (perhaps the same could be said about
-  Gamera).  It is not required for proper operation of Gamera, and is
-  only needed for those developers who wish to port Gamera to new
-  platforms or write unit tests for new code.
-
-.. __: http://codespeak.net/py/dist/test.html
-
-This document does not attempt to replicate the `py.test`__
+This document does not attempt to replicate the `pytest`__
 documentation, and will only discuss Gamera-specific additions.
 
-.. __: http://codespeak.net/py/dist/test.html
+.. __: https://pytest.org/
 
 
 Running the provided unit tests
 ===============================
 
-1. Install and test `py.test` using the instructions here__.
+1. Install and test `pytest` using the instructions here__.
 
-.. __: http://codespeak.net/py/dist/test.html
+.. __: https://pytest.org/
 
 2. From the *gamera/tests* directory, run all the unit tests with the
    command::
 
-     py.test --tb=no
+     pytest --tb=no
 
    Alternatively, you can run an individual test, say *test_graph.py* with::
 
-     py.test --tb=no test_graph.py
+     pytest --tb=no test_graph.py
 
    In case of failures you can obtain more information
    by omitting the option "--tb=no".
@@ -46,7 +38,7 @@ Running the provided unit tests
 3. If you only want to run a single test function from a unit test
    script, use the "keyword" option "-k", e.g.::
 
-     py.test -k test_glyphs_from_xml_gz test_xml.py
+     pytest -k test_glyphs_from_xml_gz test_xml.py
 
 
 Adding new unit tests
@@ -55,15 +47,15 @@ Adding new unit tests
 A new unit test, say *test_mystuff.py*, is added by the following steps:
 
 1. Create a new test script *test_mystuff.py* which imports gamera
-   and py.test:
+   and pytest:
 
 .. code:: Python
 
-   import py.test
+   import pytest
    from gamera.core import *
    init_gamera()
 
-2. Define for each test a function with the prefix ``test_``. py.test
+2. Define for each test a function with the prefix ``test_``. pytest
    will run all these functions. To verify certain results, use the
    ``assert`` statement, e.g.:
 
@@ -74,7 +66,7 @@ A new unit test, say *test_mystuff.py*, is added by the following steps:
        assert img.myplugin(3) == 42
 
 3. To verify that certain circumstances (e.g., wrong input data) lead
-   to an exception, use ``py.test.raises``:
+   to an exception, use ``pytest.raises``:
 
 .. code:: Python
 
@@ -82,11 +74,11 @@ A new unit test, say *test_mystuff.py*, is added by the following steps:
        def _fail(img):
            img.myplugin("should only be numeric")
        img = load_image("data/OneBit_generic.png")
-       py.test.raises(Exception, _fail, img)
+       pytest.raises(Exception, _fail, img)
 
-For more details, see the `py.test documentation`__.
+For more details, see the `pytest documentation`__.
 
-.. __: http://codespeak.net/py/dist/test.html
+.. __: https://pytest.org/
 
 
 Testing Gamera plugins

--- a/tests/README
+++ b/tests/README
@@ -1,22 +1,20 @@
 The tests in this directory test Gamera using the
-py.test framework.
+pytest framework.
 
-The py.test framework must be installed from 
+The pytest framework must be installed from 
 
-    http://codespeak.net/py/
+    https://pytest.org/
 
 This package is not required for the proper functioning
 of Gamera, only to run the tests. You can run all tests
 with
 
-    py.test --tb=no
+    pytest --tb=no
 
 Alternatively, you can run an individual unit test, say 
 test_graph.py, with
 
-    py.test --tb=no test_graph.py
+    pytest --tb=no test_graph.py
 
 In case of failures you can obtain more information
 by omitting the option "--tb=no".
-
-

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -15,7 +15,7 @@ def test_color_to_ccs():
         img = load_image("data/too_many_colors.png")
         labeled = img.colors_to_labels()
 
-    py.test.raises(Exception, _too_many_colors)
+    pytest.raises(Exception, _too_many_colors)
 
     # test labeling
     img = Image((0, 0), (40, 40), RGB)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1038,7 +1038,7 @@ def _test_memory_all():
 
 
 # ------------------------------------------------------------------------------
-# prepare py.test
+# prepare pytest
 class TestGraph:
     pass
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -50,7 +50,7 @@ def _test_image_constructors(type, value, storage):
     assert Rect(image) == Rect(image5)
     image6 = Image(Point(25, 25), Dim(50, 50), type, storage)
     assert Rect(image) == Rect(image6)
-    py.test.raises(TypeError, _fail1)
+    pytest.raises(TypeError, _fail1)
 
 
 test_image_constructors = make_test(_test_image_constructors)
@@ -85,8 +85,8 @@ def _test_subimage(type, value, storage):
     image7 = image.subimage(Point(30, 30), Dim(40, 40))
     assert Rect(image7) == Rect(image2)
     assert image7.data == image.data
-    py.test.raises(RuntimeError, _fail1)
-    py.test.raises(RuntimeError, _fail2)
+    pytest.raises(RuntimeError, _fail1)
+    pytest.raises(RuntimeError, _fail2)
     # image7 = image2.subimage(35, 35, 20, 20) # deprecated call
     image7 = image2.subimage(Point(35, 35), Dim(20, 20))
     assert image7.data == image.data
@@ -114,8 +114,8 @@ def _test_get_set(type, value, storage):
         for c in range(50):
             image.set((r, c), val)
             assert image.get((r, c)) == val
-    py.test.raises(IndexError, _fail1)
-    py.test.raises(IndexError, _fail2)
+    pytest.raises(IndexError, _fail1)
+    pytest.raises(IndexError, _fail2)
 
 
 test_get_set = make_test(_test_get_set)
@@ -141,8 +141,8 @@ def _test_index(type, value, storage):
         if p != val:
             print(i)
         assert p == val
-    py.test.raises(IndexError, _fail1)
-    py.test.raises(IndexError, _fail2)
+    pytest.raises(IndexError, _fail1)
+    pytest.raises(IndexError, _fail2)
 
 
 test_index = make_test(_test_index)

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 #
 # Tests for nearest neighbor finding with kd-trees
 #
@@ -17,13 +17,13 @@ def test_wrongparams():
         tree = KdTree(nodes)
 
     # all point coordinates must be numeric
-    py.test.raises(Exception, _kdnode_input, [1, 2, "a"])
-    py.test.raises(Exception, _kdnode_input, [])
+    pytest.raises(Exception, _kdnode_input, [1, 2, "a"])
+    pytest.raises(Exception, _kdnode_input, [])
     # all nodes must be KdNode's and of same dimension
-    py.test.raises(Exception, _kdtree_input, [KdNode([1, 2]), KdNode([2, 3, 4])])
-    py.test.raises(Exception, _kdtree_input, [KdNode([1, 2]), [2, 3]])
-    py.test.raises(Exception, _kdtree_input, None)
-    py.test.raises(Exception, _kdtree_input, [])
+    pytest.raises(Exception, _kdtree_input, [KdNode([1, 2]), KdNode([2, 3, 4])])
+    pytest.raises(Exception, _kdtree_input, [KdNode([1, 2]), [2, 3]])
+    pytest.raises(Exception, _kdtree_input, None)
+    pytest.raises(Exception, _kdtree_input, [])
 
 
 #

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -9,7 +9,7 @@ def test_load_image_rgb_rle():
     def _load_image_fail1():
         image = load_image("not_a_path")
 
-    py.test.raises(IOError, _load_image_fail1)
+    pytest.raises(IOError, _load_image_fail1)
 
 
 def test_load_image_onebit():
@@ -54,8 +54,8 @@ def test_load_image_greyscale_rle():
     def _load_image_greyscale_rle2():
         greyscale3 = load_image("data/GreyScale_generic.tiff", RLE)
 
-    py.test.raises(Exception, _load_image_greyscale_rle1)
-    py.test.raises(Exception, _load_image_greyscale_rle2)
+    pytest.raises(Exception, _load_image_greyscale_rle1)
+    pytest.raises(Exception, _load_image_greyscale_rle2)
 
 
 def test_load_image_rgb():
@@ -108,5 +108,5 @@ def load_image_grey16_rle2():
     grey16 = load_image("data/Grey16_generic.tiff", RLE)
 
 # def test_load_image_grey16_rle():
-#    py.test.raises(Exception, load_image_grey16_rle1)
-#    py.test.raises(Exception, load_image_grey16_rle2)
+#    pytest.raises(Exception, load_image_grey16_rle1)
+#    pytest.raises(Exception, load_image_grey16_rle2)

--- a/tests/test_mlcc.py
+++ b/tests/test_mlcc.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -9,11 +9,11 @@ def test_mlcc_wrongcalls():
     img = Image((0, 0), (8, 8))
     img.draw_filled_rect((1, 1), (3, 3), 2)
     img.set((1, 5), 3)
-    py.test.raises(Exception, MlCc, img, 2, 1)
-    py.test.raises(Exception, MlCc, img, "a", Rect((0, 0), (8, 8)))
-    py.test.raises(Exception, MlCc, "abc", 2, Rect((0, 0), (8, 8)))
-    py.test.raises(Exception, MlCc, [1, 2])
-    py.test.raises(Exception, MlCc, [img])
+    pytest.raises(Exception, MlCc, img, 2, 1)
+    pytest.raises(Exception, MlCc, img, "a", Rect((0, 0), (8, 8)))
+    pytest.raises(Exception, MlCc, "abc", 2, Rect((0, 0), (8, 8)))
+    pytest.raises(Exception, MlCc, [1, 2])
+    pytest.raises(Exception, MlCc, [img])
 
 
 def test_mlcc():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,7 +7,7 @@ from gamera import plugin
 
 # This is a fairly complex test harness, which generates
 # a "wrapper" call around every plugin so each plugin can
-# be tested separately by py.test
+# be tested separately by pytest
 
 class PluginTester(gendoc.PluginDocumentationGenerator):
     def __init__(self):

--- a/tests/test_voronoi.py
+++ b/tests/test_voronoi.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -20,11 +20,11 @@ def test_wrongparams():
         image.voronoi_from_points(points, labels)
 
     # number of points and labels must match
-    py.test.raises(Exception, _voronoi_from_points_input, [(2, 2), (5, 5)], [2, 3, 4])
+    pytest.raises(Exception, _voronoi_from_points_input, [(2, 2), (5, 5)], [2, 3, 4])
     # labels must be int's and points must be coordinates
-    py.test.raises(Exception, _voronoi_from_points_input, [(2, 2), (5, 5)], [(2, 2), (5, 5)])
+    pytest.raises(Exception, _voronoi_from_points_input, [(2, 2), (5, 5)], [(2, 2), (5, 5)])
     # TODO: no plausi check in Gamera's passing of PointVector => crash
-    # py.test.raises(Exception, _voronoi_from_points_input, [2,,5], [2,5])
+    # pytest.raises(Exception, _voronoi_from_points_input, [2,,5], [2,5])
 
 
 #

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,4 +1,4 @@
-import py.test
+import pytest
 
 from gamera.core import *
 
@@ -104,11 +104,11 @@ def test_missing_attributes():
     def _test_missing_attributes():
         glyphs = gamera_xml.glyphs_from_xml("data/missing_attributes.xml")
 
-    py.test.raises(gamera_xml.XMLError, _test_missing_attributes)
+    pytest.raises(gamera_xml.XMLError, _test_missing_attributes)
 
 
 def test_malformed():
     def _test_malformed():
         glyphs = gamera_xml.glyphs_from_xml("data/malformed.xml")
 
-    py.test.raises(gamera_xml.XMLError, _test_malformed)
+    pytest.raises(gamera_xml.XMLError, _test_malformed)


### PR DESCRIPTION
This PR ensures that the tests still work after *pytest* 7.2.0 has been released which dropped the dependency on the *py* package. Resolves #59.