### PR TITLE
Only call `pip install` once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,9 @@ jobs:
           libpng-dev
           dpkg-dev
           build-essential
-    - name: build Gamera
+    - name: build and install Gamera
       run: |
-        python -m pip install .
-    - name: install Gamera
-      run: |
-        python -m pip install .
+        python -m pip install --verbose .
     # The directory seems to be required, otherwise we get some errors:
     #    gamera.gamera_xml.XMLError: Cannot create a file at '/home/runner/work/gamera-4/gamera-4/tmp'
     - name: prepare tests


### PR DESCRIPTION
Due to the migration, there have been two identical calls to `pip install .`, while only one of them is sufficient.

This additionally enables verbose build/install output for easier analysis.