### PR TITLE
Add basic trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,24 +194,38 @@ CCompiler.compile = _compile
 
 if __name__ == "__main__":
 
-    setup(name="gamera",
-          version=gamera_version,
-          ext_modules=extensions,
-          python_requires='>=3.5',
-          license='GNU GENERAL PUBLIC LICENSE Version 2',
-          description='Gamera is a framework for building document analysis applications. It is not a packaged '
-                      'document recognition system, but a toolkit for building document image recognition systems.',
-          long_description=long_description,
-          long_description_content_type='text/markdown',
-          url="https://gamera.sourceforge.net/",
-          author="Michael Droettboom and Christoph Dalitz",
-          author_email="gamera-devel@yahoogroups.com",
-          entry_points={
-              'gui_scripts': ["gamera_gui=gamera.gamera_gui:gamera_gui"]
-          },
-          project_urls={
-              'Documentation': 'https://gamera.informatik.hsnr.de/docs/gamera-docs/',
-              'Source': 'https://github.com/hsnr-gamera/gamera-4'
-          },
-          include_package_data=True,
-          packages=packages)
+    setup(
+        name="gamera",
+        version=gamera_version,
+        ext_modules=extensions,
+        python_requires='>=3.5',
+        license='GNU GENERAL PUBLIC LICENSE Version 2',
+        description=(
+            'Gamera is a framework for building document analysis applications. It is not a packaged '
+            'document recognition system, but a toolkit for building document image recognition systems.'
+        ),
+        long_description=long_description,
+        long_description_content_type='text/markdown',
+        url="https://gamera.sourceforge.net/",
+        author="Michael Droettboom and Christoph Dalitz",
+        entry_points={
+            'gui_scripts': ["gamera_gui=gamera.gamera_gui:gamera_gui"]
+        },
+        project_urls={
+            'Documentation': 'https://gamera.informatik.hsnr.de/docs/gamera-docs/',
+            'Source': 'https://github.com/hsnr-gamera/gamera-4'
+        },
+        include_package_data=True,
+        packages=packages,
+        classifiers=[
+            'Development Status :: 5 - Production/Stable'
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3 :: Only',
+            'Topic :: Text Processing',
+            'Topic :: Multimedia :: Graphics',
+        ],
+    )

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
         include_package_data=True,
         packages=packages,
         classifiers=[
-            'Development Status :: 5 - Production/Stable'
+            'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',
             'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
             'Operating System :: OS Independent',


### PR DESCRIPTION
This commit mainly adds some basic trove classifiers, which basically correspond to Python package categories.

Additionally, I have removed the apparently defunct Yahoo Groups author e-mail (which might be replaced by another one if there should be one).