### PR TITLE
Fix some build warnings

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -19,7 +19,7 @@ Johanna Devaney
 Georg Drees
 Tim DiLauro
 Robert Ferguson
-Friedrich Fröbel
+FriedrichFröbel
 Andrew Hankinson
 Manuel Jeltsch
 Thomas Karsten

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Version 4.1.0, Feb 14, 2023
 
  - Update install instructions to use pip
 
- - ported from deprected distutils to setuptools
+ - ported from deprecated distutils to setuptools
 
  - replaced old buffer protocol
 

--- a/gamera/include/gamera/plugins/tiff_support.hpp
+++ b/gamera/include/gamera/plugins/tiff_support.hpp
@@ -68,7 +68,7 @@ ImageInfo* tiff_info(const char* filename) {
    */
   try {
     unsigned short tmp;
-    uint32 size;
+    uint32_t size;
     TIFFGetFieldDefaulted(tif, TIFFTAG_IMAGEWIDTH, &size);
     info->ncols((size_t)size);
     TIFFGetFieldDefaulted(tif, TIFFTAG_IMAGELENGTH, &size);
@@ -256,7 +256,7 @@ namespace {
         throw std::runtime_error("Error allocating scanline");
       TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISWHITE);
       std::bitset<32> bits;
-      uint32* data = (uint32 *)buf;
+      uint32_t* data = (uint32_t *)buf;
       bool little_endian = byte_order_little_endian();
       typename T::const_vec_iterator it = matrix.vec_begin();
       for (size_t i = 0; i < matrix.nrows(); i++) {

--- a/gamera/plugins/binarization.py
+++ b/gamera/plugins/binarization.py
@@ -344,7 +344,7 @@ class white_rohrer_threshold(PluginFunction):
 
 
 class shading_subtraction(PluginFunction):
-    """
+    r"""
     Thresholds an image after subtracting a -possibly shaded- background.
 
     First the background image is extracted with a maximum filter with a

--- a/gamera/plugins/id_name_matching.py
+++ b/gamera/plugins/id_name_matching.py
@@ -36,7 +36,7 @@ def build_id_regex(s):
                 part0 = part0.replace('?', '[^.]')
                 l.append(part0)
             regex_parts.append('(?:%s)' % '|'.join(['(?:%s)' % x for x in l]))
-        regex = '\.'.join(regex_parts)
+        regex = r'\.'.join(regex_parts)
         return regex
 
     def _build_id_regex_parens(s):

--- a/gamera/plugins/projections.py
+++ b/gamera/plugins/projections.py
@@ -144,7 +144,7 @@ class projection_skewed_rows(PluginFunction):
 
 
 class rotation_angle_projections(PluginFunction):
-    """
+    r"""
     Estimates the rotation angle of a document with the aid of skewed
     projections, as described in section 3.1 of C. Dalitz, G.K. Michalakis,
     C. Pranzas: 'Optical Recognition of Psaltic Byzantine Chant Notation.'

--- a/gamera/pyplate.py
+++ b/gamera/pyplate.py
@@ -56,14 +56,14 @@ PyPlate defines the following directives:
 
 import sys, string, re, gamera.util as util, io, codecs
 
-re_directive = re.compile("\[\[(.*?)\]\]")
-re_for_loop = re.compile("for (.*) in (.*)")
-re_if = re.compile("if (.*)")
-re_elif = re.compile("elif (.*)")
-re_def = re.compile("def (.*?)\((.*)\)")
-re_call = re.compile("call (.*?)\((.*)\)")
-re_exec = re.compile("exec (.*)")
-re_comment = re.compile("#(.*)#")
+re_directive = re.compile(r"\[\[(.*?)\]\]")
+re_for_loop = re.compile(r"for (.*) in (.*)")
+re_if = re.compile(r"if (.*)")
+re_elif = re.compile(r"elif (.*)")
+re_def = re.compile(r"def (.*?)\((.*)\)")
+re_call = re.compile(r"call (.*?)\((.*)\)")
+re_exec = re.compile(r"exec (.*)")
+re_comment = re.compile(r"#(.*)#")
 
 re_clean_whitespace = re.compile(r"\]\]\s+?")
 

--- a/gamera/util.py
+++ b/gamera/util.py
@@ -126,7 +126,7 @@ def string2identifier(str):
    """Defines how illegal variable names are converted to legal ones."""
    # TODO: Not very robust.
    if len(str):
-      name = re.sub('\-|/|\.|\ ', '_', str, 0)
+      name = re.sub(r'\-|/|\.|\ ', '_', str, 0)
       if name[0] in string.digits:
          name = "_" + name
       return name
@@ -339,7 +339,7 @@ def ProgressFactory(message, length=1, numsteps=0):
 # A regular expression used to determine the amount of space to
 # remove.  It looks for the first sequence of spaces immediately
 # following the first newline, or at the beginning of the string.
-_find_dedent_regex = re.compile("(?:(?:\n\r?)|^)( *)\S")
+_find_dedent_regex = re.compile(r"(?:(?:\n\r?)|^)( *)\S")
 # A cache to hold the regexs that actually remove the indent.
 _dedent_regex = {}
 def dedent(s):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = [
+    'setuptools', 'wheel',  # Needed only to make pip happy.
+]

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,14 @@ import multiprocessing
 import glob
 import os
 import platform
+import sys
+from concurrent.futures import ThreadPoolExecutor as Pool
+from pathlib import Path
 
 from setuptools import setup, Extension, find_namespace_packages
 from distutils.ccompiler import CCompiler
 from distutils.command.build_ext import build_ext
-from pathlib import Path
-import sys
+
 from gamera import gamera_setup
 
 if sys.hexversion < 0x03050000:
@@ -132,22 +134,6 @@ extensions = [Extension("gamera.gameracore",
                         include_dirs=["gamera/include/gamera", "src", "gamera/include/gamera/geostructs"],
                         **gamera_setup.extras)]
 extensions.extend(plugin_extensions)
-
-# https://stackoverflow.com/a/13176803
-# multithreading building, can also be used with setuptools
-try:
-    from concurrent.futures import ThreadPoolExecutor as Pool
-except ImportError:
-    from multiprocessing.pool import ThreadPool as LegacyPool
-
-    # To ensure the with statement works. Required for some older 2.7.x releases
-    class Pool(LegacyPool):
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            self.close()
-            self.join()
 
 
 def _build_extensions(self):

--- a/src/knncore/knncoremodule.cpp
+++ b/src/knncore/knncoremodule.cpp
@@ -1384,7 +1384,7 @@ static PyObject* knn_set_selections(PyObject* self, PyObject* args) {
 	}
 	selections = (int*)buffer.buf;
 	
-	if (buffer.len != o->num_features * sizeof(int)) {
+	if ((size_t)buffer.len != o->num_features * sizeof(int)) {
 		PyErr_SetString(PyExc_RuntimeError, "knn: selection vector is not the correct size.");
 		return nullptr;
 	}
@@ -1420,7 +1420,7 @@ static PyObject* knn_set_weights(PyObject* self, PyObject* args) {
 		return nullptr;
 	}
 	weights = (double*)buffer.buf;
-	if (buffer.len != o->num_features * sizeof(double)) {
+	if ((size_t)buffer.len != o->num_features * sizeof(double)) {
 		PyErr_SetString(PyExc_ValueError, "knn: weight vector is not the correct size.");
 		return nullptr;
 	}


### PR DESCRIPTION
This PR fixes some build warnings I stumbled upon while testing the compatibility of Gamera with the upcoming Python 3.12 release.

Included fixes:

### `pkg_resources.parse_version` is deprecated

```
../../../../../opt/hostedtoolcache/Python/3.12.0-alpha.7/x64/lib/python3.12/site-packages/pkg_resources/__init__.py:121
  /opt/hostedtoolcache/Python/3.12.0-alpha.7/x64/lib/python3.12/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
```

The `pkg_resources.parse_version` calls have been removed completely, as `docutils==0.4` and `pygments==0.6` have been released in 2006. Additionally, support for lexing using `SilverCity` has been dropped as well, as the package had its last release in 2005: https://pypi.org/project/SilverCity/

### Invalid escape sequences for regex expressions

```
  /home/runner/work/gamera-4/gamera-4/gamera/pyplate.py:59: SyntaxWarning: invalid escape sequence '\['
    re_directive = re.compile("\[\[(.*?)\]\]")
  /home/runner/work/gamera-4/gamera-4/gamera/pyplate.py:63: SyntaxWarning: invalid escape sequence '\('
    re_def = re.compile("def (.*?)\((.*)\)")
  /home/runner/work/gamera-4/gamera-4/gamera/pyplate.py:64: SyntaxWarning: invalid escape sequence '\('
    re_call = re.compile("call (.*?)\((.*)\)")
```

There were multiple places where I got syntax warnings due to invalid escape sequences. This has been fixed by converting this strings to raw ones.

### Comparison of integer expressions of different signedness

```
  src/knncore/knncoremodule.cpp: In function ‘PyObject* knn_set_selections(PyObject*, PyObject*)’:
  src/knncore/knncoremodule.cpp:1387:24: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   1387 |         if (buffer.len != o->num_features * sizeof(int)) {
        |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/knncore/knncoremodule.cpp: In function ‘PyObject* knn_set_weights(PyObject*, PyObject*)’:
  src/knncore/knncoremodule.cpp:1423:24: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   1423 |         if (buffer.len != o->num_features * sizeof(double)) {
        |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

There have been some length comparisons with non-matching data types, which has been corrected by applying the corresponding cast on the left-hand sides.

### uint32 deprecation warnings from libtiff

```
  /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp: In function ‘Gamera::ImageInfo* Gamera::tiff_info(const char*)’:
  /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:71:12: warning: ‘uint32’ is deprecated [-Wdeprecated-declarations]
     71 |     uint32 size;
        |            ^~~~
  In file included from /usr/include/x86_64-linux-gnu/tiffio.h:31,
                   from /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:28,
                   from gamera/plugins/_tiff_support.cpp:7:
  /usr/include/x86_64-linux-gnu/tiff.h:84:38: note: declared here
     84 | typedef TIFF_MSC_DEPRECATED uint32_t uint32 TIFF_GCC_DEPRECATED;
        |                                      ^~~~~~
  In file included from gamera/plugins/_tiff_support.cpp:7:
  /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp: In member function ‘void Gamera::{anonymous}::tiff_saver<short unsigned int>::operator()(const T&, TIFF*)’:
  /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:259:15: warning: ‘uint32’ is deprecated [-Wdeprecated-declarations]
    259 |       uint32* data = (uint32 *)buf;
        |               ^~~~
  In file included from /usr/include/x86_64-linux-gnu/tiffio.h:31,
                   from /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:28,
                   from gamera/plugins/_tiff_support.cpp:7:
  /usr/include/x86_64-linux-gnu/tiff.h:84:38: note: declared here
     84 | typedef TIFF_MSC_DEPRECATED uint32_t uint32 TIFF_GCC_DEPRECATED;
        |                                      ^~~~~~
  In file included from gamera/plugins/_tiff_support.cpp:7:
  /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:259:30: warning: ‘uint32’ is deprecated [-Wdeprecated-declarations]
    259 |       uint32* data = (uint32 *)buf;
        |                              ^
  In file included from /usr/include/x86_64-linux-gnu/tiffio.h:31,
                   from /home/runner/work/gamera-4/gamera-4/gamera/include/gamera/plugins/tiff_support.hpp:28,
                   from gamera/plugins/_tiff_support.cpp:7:
  /usr/include/x86_64-linux-gnu/tiff.h:84:38: note: declared here
     84 | typedef TIFF_MSC_DEPRECATED uint32_t uint32 TIFF_GCC_DEPRECATED;
        |                                      ^~~~~~
```

The corresponding sections have been replaced to use the `_t` type versions (standardized C99 types) as proposed in http://libtiff.maptools.org/v4.3.0.html

### Drop old multiprocessing.pool workaround

The `multiprocessing.pool` workaround for the build (instead of `concurrent.futures`) has been removed as it has been documented to be for some older Python 2.x releases only. As we are not supporting Python 2 any more, this is not required here.

### `setup.py install` deprecation warning

```
 /opt/hostedtoolcache/Python/3.12.0-alpha.7/x64/lib/python3.12/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
    warnings.warn(
```

Strangely enough, we have already been using `pip install .` beforehand. According to https://stackoverflow.com/questions/70970858/what-is-the-best-replacement-for-python-setup-py-install-when-cython-needs-to-be, a `pyproject.toml` file avoids this and thus has been implemented.