### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   main:
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python }}
     steps:

--- a/gamera/gui/gui_util.py
+++ b/gamera/gui/gui_util.py
@@ -232,8 +232,8 @@ else:
 
    def docstring_to_html(docstring):
       try:
-         corrected = docstring.replace("*args", "\*args")
-         corrected = corrected.replace("**kwargs", "\*\*kwargs")
+         corrected = docstring.replace("*args", r"\*args")
+         corrected = corrected.replace("**kwargs", r"\*\*kwargs")
          html = docutils.core.publish_string(corrected, writer_name="html")
       except Exception as e:
          html = '''<pre>%s</pre><br/<br/><font size=1><pre>%s</pre></font>''' % (docstring, str(e))

--- a/gamera/io.py
+++ b/gamera/io.py
@@ -229,7 +229,7 @@ Returns: a list of strings, one per line in each text file specified by
 
 
 def getcsv (namepatterns, delimiter='\t', verbose=1):
-    """
+    r"""
 Loads a list of lists from text files (specified by a UNIX-style
 wildcard filename pattern) and converts all numeric values to floats.
 Uses the glob module for filename pattern conversion.  Loaded filename

--- a/gamera/plugins/contour.py
+++ b/gamera/plugins/contour.py
@@ -70,7 +70,7 @@ class contour_right(Contour):
   pass
 
 class contour_samplepoints(PluginFunction):
-  """
+  r"""
   Returns a point vector containing contour points of the given image.
   
   *percentage*:
@@ -108,7 +108,7 @@ class contour_samplepoints(PluginFunction):
   __call__ = staticmethod(__call__)
 
 class contour_pavlidis(PluginFunction):
-    """
+    r"""
     Returns a point list of the outer contour trace found with Pavlidis'
     algorithm (T. Pavlidis: *Algorithms for Grapics and Image Processing.*
     pp. 129-165, Springer, 1982).

--- a/gamera/plugins/contour.py
+++ b/gamera/plugins/contour.py
@@ -70,7 +70,7 @@ class contour_right(Contour):
   pass
 
 class contour_samplepoints(PluginFunction):
-  r"""
+  """
   Returns a point vector containing contour points of the given image.
   
   *percentage*:
@@ -78,8 +78,8 @@ class contour_samplepoints(PluginFunction):
     equidistant on the contour.
 
   *contour*:
-    when 0 (\"outer_projection\"), the points returned by *contour_left* etc.
-    are used; when 1 (\"full_contour\") the points returned by *outline(1)*
+    when 0 ("outer_projection"), the points returned by *contour_left* etc.
+    are used; when 1 ("full_contour") the points returned by *outline(1)*
     are used.
   
   In addition to the points determined by the percentage argument the result

--- a/gamera/plugins/edgedetect.py
+++ b/gamera/plugins/edgedetect.py
@@ -147,7 +147,7 @@ class labeled_region_edges(PluginFunction):
   __call__ = staticmethod(__call__)
 
 class outline(PluginFunction):
-    """
+    r"""
     Traces the outline of the image.  When *which* is 0 (\"outer\"),
     the result is obtained by dilating the image and then XOR'ing the
     result with the original; when *which* is 1 (\"inner\"), the result

--- a/gamera/plugins/edgedetect.py
+++ b/gamera/plugins/edgedetect.py
@@ -147,10 +147,10 @@ class labeled_region_edges(PluginFunction):
   __call__ = staticmethod(__call__)
 
 class outline(PluginFunction):
-    r"""
-    Traces the outline of the image.  When *which* is 0 (\"outer\"),
+    """
+    Traces the outline of the image.  When *which* is 0 ("outer"),
     the result is obtained by dilating the image and then XOR'ing the
-    result with the original; when *which* is 1 (\"inner\"), the result
+    result with the original; when *which* is 1 ("inner"), the result
     is obtained by eroding the image and then XOR'ing the
     result with the original.
     """

--- a/gamera/plugins/features.py
+++ b/gamera/plugins/features.py
@@ -50,14 +50,14 @@ class black_area(Feature):
 
 
 class moments(Feature):
-    r"""
+    """
     Returns *moments* of the image.
 
     The first two elements of the returned ``FloatVector`` are the 
     center of gravity on *x* and *y* axis normalized by width and height,
     respectively. The following seven entries are the 
     *normalized central moments* (*u20,u02,u11,u30,u12,u21,u03*). For their
-    definition, see Gonzalez, Woods: \"Digital Image Processing\",
+    definition, see Gonzalez, Woods: "Digital Image Processing",
     Prentice Hall, second edition (2002).
 
     +---------------------------+
@@ -228,9 +228,9 @@ class compactness(Feature):
 
 
 class volume16regions(Feature):
-    r"""
+    """
     Divides the image into a 4 x 4 grid of 16 regions and calculates
-    the volume within each. This feature is also known as \"zoning\" method.
+    the volume within each. This feature is also known as "zoning" method.
 
     +---------------------------+
     | **Invariant to:**         |  
@@ -244,9 +244,9 @@ class volume16regions(Feature):
 
 
 class volume64regions(Feature):
-    r"""
+    """
     Divides the image into an 8 x 8 grid of 64 regions and calculates
-    the volume within each. This feature is also known as \"zoning\" method.
+    the volume within each. This feature is also known as "zoning" method.
 
     +---------------------------+
     | **Invariant to:**         |  
@@ -260,7 +260,7 @@ class volume64regions(Feature):
 
 
 class zernike_moments(Feature):
-    r"""
+    """
     Computes the absolute values of the Normalized Zernike Moments up to
     order six.
 
@@ -272,8 +272,8 @@ class zernike_moments(Feature):
     The present implementation normalizes the Zernike moments by
     division with the zeroeth geometric moment *m00*, which results
     in an approximate scale invariance according to
-    S. Belkasim, E. Hassan, T. Obeidi: \"Explicit invariance of Cartesian
-    Zernike moments.\" Pattern Recognition Letters 28, pp. 1969-1980 (2007)
+    S. Belkasim, E. Hassan, T. Obeidi: "Explicit invariance of Cartesian
+    Zernike moments." Pattern Recognition Letters 28, pp. 1969-1980 (2007)
 
     The return values are the absolute values of
     *A20, A22, A31, A33, A40, A42, A44, A51, A53, A54, A60, A62, A64, A66*.
@@ -293,7 +293,7 @@ class zernike_moments(Feature):
 
 
 class zernike_moments_plugin(PluginFunction):
-    r"""
+    """
     Computes the absolute values of the Normalized Zernike Moments up to
     the given order. This is separate from the feature *zernike_moments*,
     because features only support onebit images, so we need a different
@@ -307,8 +307,8 @@ class zernike_moments_plugin(PluginFunction):
     The present implementation normalizes the Zernike moments by
     division with the zeroeth geometric moment *m00*, which results
     in an approximate scale invariance according to
-    S. Belkasim, E. Hassan, T. Obeidi: \"Explicit invariance of Cartesian
-    Zernike moments.\" Pattern Recognition Letters 28, pp. 1969-1980 (2007)
+    S. Belkasim, E. Hassan, T. Obeidi: "Explicit invariance of Cartesian
+    Zernike moments." Pattern Recognition Letters 28, pp. 1969-1980 (2007)
 
     The return values are the absolute values of
     *A20, A22, A31, A33, A40, A42, A44, A51, A53, A54, A60, A62, A64, A66*.

--- a/gamera/plugins/features.py
+++ b/gamera/plugins/features.py
@@ -50,7 +50,7 @@ class black_area(Feature):
 
 
 class moments(Feature):
-    """
+    r"""
     Returns *moments* of the image.
 
     The first two elements of the returned ``FloatVector`` are the 
@@ -228,7 +228,7 @@ class compactness(Feature):
 
 
 class volume16regions(Feature):
-    """
+    r"""
     Divides the image into a 4 x 4 grid of 16 regions and calculates
     the volume within each. This feature is also known as \"zoning\" method.
 
@@ -244,7 +244,7 @@ class volume16regions(Feature):
 
 
 class volume64regions(Feature):
-    """
+    r"""
     Divides the image into an 8 x 8 grid of 64 regions and calculates
     the volume within each. This feature is also known as \"zoning\" method.
 
@@ -260,7 +260,7 @@ class volume64regions(Feature):
 
 
 class zernike_moments(Feature):
-    """
+    r"""
     Computes the absolute values of the Normalized Zernike Moments up to
     order six.
 
@@ -293,7 +293,7 @@ class zernike_moments(Feature):
 
 
 class zernike_moments_plugin(PluginFunction):
-    """
+    r"""
     Computes the absolute values of the Normalized Zernike Moments up to
     the given order. This is separate from the feature *zernike_moments*,
     because features only support onebit images, so we need a different

--- a/gamera/plugins/geometry.py
+++ b/gamera/plugins/geometry.py
@@ -214,7 +214,7 @@ class delaunay_from_points(PluginFunction):
 
 
 class graph_color_ccs(PluginFunction):
-    r"""
+    """
     Returns an RGB Image where each segment is colored with one of the colors
     from *colors* in such a way that neighboring segments have different
     colors. Optionally, each segment can also be colored uniquely with
@@ -223,7 +223,7 @@ class graph_color_ccs(PluginFunction):
     Reference:
 
       C. Dalitz, T. Bolten, O. Christion:
-      `\"Color Visualization of 2D Segmentations.\"`__
+      `"Color Visualization of 2D Segmentations."`__
       International Conference on Information Visualization Theory
       and Applications (IVAPP), pp. 567-572 (2013)
 
@@ -349,7 +349,7 @@ by convex_hull_as_points_.
 
 
 class max_empty_rect(PluginFunction):
-   r"""Returns the maximum area empty rect that fits into the image without
+   """Returns the maximum area empty rect that fits into the image without
 containing any of the black image pixels. This problem is in the literature
 generally known as the *Largest Empty Rectangle Problem*.
 
@@ -357,7 +357,7 @@ When the image does not contain a white pixel at all, an exception of type
 ``RuntimeError`` is thrown. The coordinates of the returned rectangle are
 relative to the upper left corner of the image.
 
-Reference: D. Vandevoorde: `\"The Maximal Rectangle Problem.\"`__ Dr. Dobb's,
+Reference: D. Vandevoorde: `"The Maximal Rectangle Problem."`__ Dr. Dobb's,
 April 1998.
 
 .. __: http://www.drdobbs.com/database/184410529

--- a/gamera/plugins/geometry.py
+++ b/gamera/plugins/geometry.py
@@ -214,7 +214,7 @@ class delaunay_from_points(PluginFunction):
 
 
 class graph_color_ccs(PluginFunction):
-    """
+    r"""
     Returns an RGB Image where each segment is colored with one of the colors
     from *colors* in such a way that neighboring segments have different
     colors. Optionally, each segment can also be colored uniquely with
@@ -349,7 +349,7 @@ by convex_hull_as_points_.
 
 
 class max_empty_rect(PluginFunction):
-   """Returns the maximum area empty rect that fits into the image without
+   r"""Returns the maximum area empty rect that fits into the image without
 containing any of the black image pixels. This problem is in the literature
 generally known as the *Largest Empty Rectangle Problem*.
 

--- a/gamera/plugins/image_utilities.py
+++ b/gamera/plugins/image_utilities.py
@@ -287,7 +287,7 @@ class nested_list_to_image(PluginFunction):
     __call__ = staticmethod(__call__)
 
 class diff_images(PluginFunction):
-    """
+    r"""
     Returns a color image representing the difference of two images
     following the conventions of a number of Unix diff visualization
     tools, such as CVS web.  Pixels in both images are black.  Pixels

--- a/gamera/plugins/image_utilities.py
+++ b/gamera/plugins/image_utilities.py
@@ -287,12 +287,12 @@ class nested_list_to_image(PluginFunction):
     __call__ = staticmethod(__call__)
 
 class diff_images(PluginFunction):
-    r"""
+    """
     Returns a color image representing the difference of two images
     following the conventions of a number of Unix diff visualization
     tools, such as CVS web.  Pixels in both images are black.  Pixels
-    in 'self' but not in the given image (\"deleted\" pixels) are red.
-    Pixels in the given image but not in self (\"inserted\" pixels)
+    in 'self' but not in the given image ("deleted" pixels) are red.
+    Pixels in the given image but not in self ("inserted" pixels)
     are green.
     """
     category = "Combine"

--- a/gamera/plugins/listutilities.py
+++ b/gamera/plugins/listutilities.py
@@ -112,8 +112,8 @@ class median_py(PluginFunction):
     author = "Christoph Dalitz"
 
 class kernel_density(PluginFunction):
-    r"""Computes the kernel density for *values* at the specified
-*x*-positions. Reference: S.J. Sheather: \"Density Estimation.\"
+    """Computes the kernel density for *values* at the specified
+*x*-positions. Reference: S.J. Sheather: "Density Estimation."
 Statistical Science 19 pp. 588-597 (2004).
 
 Arguments:

--- a/gamera/plugins/listutilities.py
+++ b/gamera/plugins/listutilities.py
@@ -112,7 +112,7 @@ class median_py(PluginFunction):
     author = "Christoph Dalitz"
 
 class kernel_density(PluginFunction):
-    """Computes the kernel density for *values* at the specified
+    r"""Computes the kernel density for *values* at the specified
 *x*-positions. Reference: S.J. Sheather: \"Density Estimation.\"
 Statistical Science 19 pp. 588-597 (2004).
 

--- a/gamera/plugins/pagesegmentation.py
+++ b/gamera/plugins/pagesegmentation.py
@@ -434,7 +434,7 @@ class sub_cc_analysis(PluginFunction):
 
 
 class textline_reading_order(PluginFunction):
-    """
+    r"""
     Sorts a list of Images (CCs) representing textlines by reading order and
     returns the sorted list. Incidentally, this will not only work on
     textlines, but also on paragraphs, but *not* on actual Connected 

--- a/gamera/plugins/pagesegmentation.py
+++ b/gamera/plugins/pagesegmentation.py
@@ -434,7 +434,7 @@ class sub_cc_analysis(PluginFunction):
 
 
 class textline_reading_order(PluginFunction):
-    r"""
+    """
     Sorts a list of Images (CCs) representing textlines by reading order and
     returns the sorted list. Incidentally, this will not only work on
     textlines, but also on paragraphs, but *not* on actual Connected 
@@ -444,12 +444,12 @@ class textline_reading_order(PluginFunction):
     the following criteria for the pairwise order of two lines:
 
     - line *a* comes before line *b* when *a* is totally to the left
-      of *b* (order \"column before row\")
+      of *b* (order "column before row")
 
     - line *a* comes before *b* when both overlap horizontally and
       *a* is above *b* (order within a column)
 
-    In the reference `\"High Performance Document Analysis\"`__
+    In the reference `"High Performance Document Analysis"`__
     by T.M. Breuel (Symposium on Document Image Understanding,
     USA, pp. 209-218, 2003),
     an additional constraint is made for the first criterion by demanding

--- a/gamera/plugins/threshold.py
+++ b/gamera/plugins/threshold.py
@@ -237,9 +237,9 @@ class djvu_threshold(PluginFunction):
     doc_examples = [(RGB, 0.5, 512, 64, 2)]
 
 class soft_threshold(PluginFunction):
-    r"""
-    Does a greyscale transformation that \"smears out\" the threshold *t* by a
-    choosable amount *sigma*. This has the effect of a \"soft\" thresholding.
+    """
+    Does a greyscale transformation that "smears out" the threshold *t* by a
+    choosable amount *sigma*. This has the effect of a "soft" thresholding.
 
     Each grey value *x* is transformed to *F(x,t,sigma)*, where *F*
     is the CDF probability distribution with mean *t* and variance
@@ -257,7 +257,7 @@ class soft_threshold(PluginFunction):
 
 .. __: #otsu-find-threshold
 
-    Reference: C. Dalitz: `\"Soft Thresholding for Visual Image Enhancement.\"`__
+    Reference: C. Dalitz: `"Soft Thresholding for Visual Image Enhancement."`__
     Technischer Bericht Nr. 2014-01, Hochschule Niederrhein,
     Fachbereich Elektrotechnik und Informatik, 2014
 
@@ -275,13 +275,13 @@ class soft_threshold(PluginFunction):
     doc_examples = [(GREYSCALE, 128, 25)]
 
 class soft_threshold_find_sigma(PluginFunction):
-    r"""
+    """
     For the CDF probability distribution given by *dist*
     (0 = logistic, 1 = normal (gaussian), 2 = uniform), sigma is
     determined such that *F(m,t,sigma)* = 0.99, where *m* is the mean grey
     value of all pixels with a grey value greater than *t*.
 
-    Reference: C. Dalitz: `\"Soft Thresholding for Visual Image Enhancement.\"`__
+    Reference: C. Dalitz: `"Soft Thresholding for Visual Image Enhancement."`__
     Technischer Bericht Nr. 2014-01, Hochschule Niederrhein,
     Fachbereich Elektrotechnik und Informatik, 2014
 

--- a/gamera/plugins/threshold.py
+++ b/gamera/plugins/threshold.py
@@ -237,7 +237,7 @@ class djvu_threshold(PluginFunction):
     doc_examples = [(RGB, 0.5, 512, 64, 2)]
 
 class soft_threshold(PluginFunction):
-    """
+    r"""
     Does a greyscale transformation that \"smears out\" the threshold *t* by a
     choosable amount *sigma*. This has the effect of a \"soft\" thresholding.
 
@@ -275,7 +275,7 @@ class soft_threshold(PluginFunction):
     doc_examples = [(GREYSCALE, 128, 25)]
 
 class soft_threshold_find_sigma(PluginFunction):
-    """
+    r"""
     For the CDF probability distribution given by *dist*
     (0 = logistic, 1 = normal (gaussian), 2 = uniform), sigma is
     determined such that *F(m,t,sigma)* = 0.99, where *m* is the mean grey

--- a/gamera/pstat.py
+++ b/gamera/pstat.py
@@ -392,7 +392,7 @@ Returns: the rows of listoflists where columnlist[i]=valuelist[i] for ANY i
 
 
 def linedelimited (inlist,delimiter):
-    """
+    r"""
 Returns a string composed of elements in inlist, with each element
 separated by 'delimiter.'  Used by function writedelimited.  Use '\t'
 for tab-delimiting.
@@ -488,7 +488,7 @@ def makestr (x):
 
 
 def printcc (lst,extra=2):
-    """
+    r"""
 Prints a list of lists in columns, customized by the max size of items
 within the columns (max size of items in col, plus 'extra' number of spaces).
 Use 'dashes' or '\\n' in the list-of-lists to print dashes or blank lines,

--- a/gamera/ruleengine.py
+++ b/gamera/ruleengine.py
@@ -25,7 +25,7 @@ from inspect import isfunction
 from gamera import group, util
 from .fudge import Fudge
 
-"""This module provides tools for applying graph-rewriting rules to a
+r"""This module provides tools for applying graph-rewriting rules to a
 set of glyphs.
 
 It would seem nice to invent a completely new language for this task


### PR DESCRIPTION
Closes #73 by running `ruff check --select W605,D301 --fix --unsafe-fixes`. Some of the warnings have already been resolved in #71 before.

Additionally, CI has been updated for the latest supported Python versions.