### PR TITLE
Modernize C++ code: replace deprecated std::random_shuffle and std::binary_function

### DIFF
--- a/gamera/include/gamera/plugins/geometry.hpp
+++ b/gamera/include/gamera/plugins/geometry.hpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <stack>
 #include <algorithm>
+#include <random>
 #include "gamera.hpp"
 #include "vigra/distancetransform.hxx"
 #include "vigra/seededregiongrowing.hxx"
@@ -319,7 +320,9 @@ namespace Gamera {
       ++pv_it;
       ++lv_it;
     }
-    random_shuffle(vertices.begin(), vertices.end());
+    random_device rd;
+    mt19937 g(rd());
+    shuffle(vertices.begin(), vertices.end(), g);
     dt.addVertices(&vertices);
     dt.neighboringLabels(result);
     for(it = vertices.begin() ; it != vertices.end() ; ++it) {

--- a/gamera/include/gamera/plugins/logical.hpp
+++ b/gamera/include/gamera/plugins/logical.hpp
@@ -95,7 +95,7 @@ or_image(T& a, const U& b, bool in_place=true) {
 
 // We make our own, since logical_xor is not in STL
 template <class _Tp>
-struct logical_xor : public std::binary_function<_Tp,_Tp,bool>
+struct logical_xor 
 {
   bool operator()(const _Tp& __x, const _Tp& __y) const { return __x ^ __y; }
 };


### PR DESCRIPTION
- Replaced `std::random_shuffle` with `std::shuffle` and a properly seeded `std::mt19937` generator and added '#include <random>'
- Removed inheritance from `std::binary_function` to eliminate deprecated usage (the operator itself remains unchanged).